### PR TITLE
Use Geant4 trajectories instead of stepping action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,5 @@ cython_debug/
 
 # IntelliJ IDEs project space
 .idea/*
+
+tmp/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,10 @@ dd4hep_set_compiler_flags()
 
 file(GLOB sources CONFIGURE_DEPENDS src/*.cpp)
 dd4hep_add_plugin(${a_lib_name}
-  SOURCES ${sources}
+  SOURCES
+        src/DD4hepTrajectoryWriterEventAction.cpp
+        src/TestSteppingAction.cpp
+        src/TextDumpingSteppingAction.cpp
   USES ROOT::Core ROOT::Gdml
   )
 

--- a/src/DD4hepTrajectoryWriterEventAction.cpp
+++ b/src/DD4hepTrajectoryWriterEventAction.cpp
@@ -1,0 +1,302 @@
+//==========================================================================
+//  AIDA Detector description implementation
+//--------------------------------------------------------------------------
+// Implementation of the TrajectoryWriterEventAction as a DD4hep/DDG4 plugin
+//==========================================================================
+
+// Framework include files
+#include "DDG4/Geant4EventAction.h"
+#include "DD4hep/Printout.h"
+#include "DDG4/Geant4Kernel.h"
+
+// Geant4 headers
+#include "G4Event.hh"
+#include "G4TrajectoryContainer.hh"
+#include "G4VTrajectory.hh"
+#include "G4VTrajectoryPoint.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4UnitsTable.hh"
+#include "G4AttValue.hh"
+#include "G4AttDef.hh"
+#include "G4RichTrajectory.hh"
+#include "G4RichTrajectoryPoint.hh"
+#include "G4SmoothTrajectory.hh"
+#include "G4SmoothTrajectoryPoint.hh"
+#include "G4Trajectory.hh"
+#include "G4TrajectoryPoint.hh"
+
+// C/C++ headers
+#include <fstream>
+#include <iostream>
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+
+    /**
+     * \addtogroup Geant4EventAction
+     * @{
+     * \package TrajectoryWriterEventAction
+     * \brief Writes out all trajectories to a CSV file
+     *
+     *  This action writes out trajectories collected during Geant4 simulation.
+     *  Requires trajectories to be enabled via /tracking/storeTrajectory command.
+     *
+     * @}
+     */
+
+    /// Trajectory writer event action for dd4hep simulation
+    /** This action writes all trajectories to a CSV file
+     *
+     *  \author  Your Namewe
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class TrajectoryWriterEventAction : public Geant4EventAction {
+    protected:
+      /// Property: output file name
+      std::string m_outputFile {"trajectories.csv"};
+
+      /// Output file stream
+      std::ofstream m_output;
+
+      /// Write header flag
+      bool m_writeHeader {true};
+
+    public:
+      /// Standard constructor
+      TrajectoryWriterEventAction(Geant4Context* context, const std::string& name = "TrajectoryWriterEventAction")
+        : Geant4EventAction(context, name)
+      {
+        declareProperty("OutputFile", m_outputFile);
+
+        // Open the output file at initialization
+        m_output.open(m_outputFile, std::ios::out);
+        if (!m_output.is_open()) {
+          fatal("+++ Failed to open trajectory output file: %s", m_outputFile.c_str());
+          throw std::runtime_error("Failed to open trajectory output file");
+        }
+        info("+++ Successfully opened trajectory output file: %s", m_outputFile.c_str());
+      }
+
+      /// Destructor
+      virtual ~TrajectoryWriterEventAction() {
+        if (m_output.is_open()) {
+          m_output.close();
+        }
+      }
+
+      /// Begin-of-event callback
+      virtual void begin(const G4Event* /* event */) override {
+        // Nothing to do at begin of event
+      }
+
+      /// Write trajectory points for a specific trajectory with detailed information
+      void writeTrajectoryPoints(G4VTrajectory* trajectory, G4int eventID, G4int trackID) {
+        G4int n_points = trajectory->GetPointEntries();
+        info("+++ Writing %d trajectory points for track %d", n_points, trackID);
+
+
+        for (G4int i = 0; i < n_points; i++) {
+          G4VTrajectoryPoint* point = trajectory->GetPoint(i);
+          G4ThreeVector position = point->GetPosition();
+
+          // Create a base record for this point
+          std::stringstream pointRecord;
+          pointRecord << "POINT,"
+                     << eventID << ","
+                     << trackID << ","
+                     << i << ","
+                     << position.x()/mm << ","
+                     << position.y()/mm << ","
+                     << position.z()/mm;
+
+          // Additional information for different point types
+          G4RichTrajectoryPoint* richPoint = dynamic_cast<G4RichTrajectoryPoint*>(point);
+          if (richPoint) {
+            // Rich trajectory point has detailed information
+            std::vector<G4AttValue>* attValues = richPoint->CreateAttValues();
+
+            // Add all available values from the rich point
+            // Initialize variables for common attributes
+            G4double energyDeposit = 0.0;
+            G4double remainingEnergy = 0.0;
+            std::string processName = "None";
+            std::string processType = "None";
+            std::string preStatus = "None";
+            std::string postStatus = "None";
+            G4double preTime = 0.0;
+            G4double postTime = 0.0;
+            G4double preWeight = 0.0;
+            G4double postWeight = 0.0;
+
+            // Extract values from AttValues
+            for (const auto& attValue : *attValues) {
+              std::string name = attValue.GetName();
+              std::string value = attValue.GetValue();
+
+              // Extract numeric values from G4BestUnit format
+              if (name == "TED") {
+                // TED = Total Energy Deposit
+                std::istringstream iss(value);
+                iss >> energyDeposit;
+              }
+              else if (name == "RE") {
+                // RE = Remaining Energy
+                std::istringstream iss(value);
+                iss >> remainingEnergy;
+              }
+              else if (name == "PDS") {
+                // PDS = Process Defined Step
+                processName = value;
+              }
+              else if (name == "PTDS") {
+                // PTDS = Process Type Defined Step
+                processType = value;
+              }
+              else if (name == "PreStatus") {
+                preStatus = value;
+              }
+              else if (name == "PostStatus") {
+                postStatus = value;
+              }
+              else if (name == "PreT") {
+                std::istringstream iss(value);
+                iss >> preTime;
+              }
+              else if (name == "PostT") {
+                std::istringstream iss(value);
+                iss >> postTime;
+              }
+              else if (name == "PreW") {
+                std::istringstream iss(value);
+                iss >> preWeight;
+              }
+              else if (name == "PostW") {
+                std::istringstream iss(value);
+                iss >> postWeight;
+              }
+            }
+
+            // Add rich information to point record
+            pointRecord << ","
+                        << energyDeposit/CLHEP::MeV << ","   // Energy deposit in MeV
+                        << remainingEnergy/CLHEP::MeV << "," // Remaining energy in MeV
+                        << processName << ","
+                        << processType << ","
+                        << preStatus << ","
+                        << postStatus << ","
+                        << preTime/CLHEP::ns << ","          // Pre-step time in ns
+                        << postTime/CLHEP::ns << ","         // Post-step time in ns
+                        << preWeight << ","
+                        << postWeight;
+
+            // Clean up
+            delete attValues;
+          }
+
+          // Write the point record
+          m_output << pointRecord.str() << std::endl;
+
+          // Handle auxiliary points for smooth trajectories
+          G4SmoothTrajectoryPoint* smoothPoint = dynamic_cast<G4SmoothTrajectoryPoint*>(point);
+          if (smoothPoint) {
+            const std::vector<G4ThreeVector>* auxPoints = smoothPoint->GetAuxiliaryPoints();
+            if (auxPoints && !auxPoints->empty()) {
+              info("+++ Writing %d auxiliary points for point %d of track %d",
+                   (int)auxPoints->size(), i, trackID);
+
+              for (size_t j = 0; j < auxPoints->size(); j++) {
+                const G4ThreeVector& auxPos = (*auxPoints)[j];
+                m_output << "AUXPOINT,"
+                        << eventID << ","
+                        << trackID << ","
+                        << i << "." << j << ","
+                        << auxPos.x()/mm << ","
+                        << auxPos.y()/mm << ","
+                        << auxPos.z()/mm
+                        << std::endl;
+              }
+            }
+          }
+        }
+      }
+
+      /// End-of-event callback to write trajectories
+      virtual void end(const G4Event* event) override {
+        G4TrajectoryContainer* trajectoryContainer = event->GetTrajectoryContainer();
+        if (!trajectoryContainer) return;
+
+        G4int n_trajectories = trajectoryContainer->entries();
+        if (n_trajectories == 0) return;
+
+        // Write header if needed
+        if (m_writeHeader) {
+          m_output << "# Event,TrackID,ParentID,ParticleName,PDGEncoding,Charge,InitialKineticEnergy[MeV],"
+                  << "InitialMomentumX[MeV],InitialMomentumY[MeV],InitialMomentumZ[MeV]"
+                  << std::endl;
+
+          // Header for trajectory points file - detailed format
+          m_output << "# Point format for regular trajectories:" << std::endl;
+          m_output << "# POINT,EventID,TrackID,PointIndex,X[mm],Y[mm],Z[mm]" << std::endl;
+          m_output << "# Point format for rich trajectories:" << std::endl;
+          m_output << "# POINT,EventID,TrackID,PointIndex,X[mm],Y[mm],Z[mm],EnergyDeposit[MeV],RemainingEnergy[MeV],"
+                  << "ProcessName,ProcessType,PreStepStatus,PostStepStatus,PreTime[ns],PostTime[ns],PreWeight,PostWeight"
+                  << std::endl;
+          m_output << "# AuxPoint format for smooth trajectories:" << std::endl;
+          m_output << "# AUXPOINT,EventID,TrackID,PointIndex.SubIndex,X[mm],Y[mm],Z[mm]"
+                  << std::endl;
+
+          m_writeHeader = false;
+        }
+
+        G4int eventID = event->GetEventID();
+        info("+++ Writing %d trajectories for event %d", n_trajectories, eventID);
+
+        // Process each trajectory
+        for (G4int i = 0; i < n_trajectories; i++) {
+          G4VTrajectory* trajectory = (*trajectoryContainer)[i];
+
+          // Write trajectory summary info
+          m_output << eventID << ","
+                  << trajectory->GetTrackID() << ","
+                  << trajectory->GetParentID() << ","
+                  << trajectory->GetParticleName() << ","
+                  << trajectory->GetPDGEncoding() << ","
+                  << trajectory->GetCharge() << ",";
+
+          // Get extended trajectory properties using the specific trajectory type
+          G4double initialKE = 0.0;
+          G4ThreeVector initialMomentum = trajectory->GetInitialMomentum();
+
+          // G4Trajectory and derivatives define GetInitialKineticEnergy()
+          if (G4Trajectory* trajNormal = dynamic_cast<G4Trajectory*>(trajectory)) {
+            initialKE = trajNormal->GetInitialKineticEnergy();
+          }
+          else if (G4RichTrajectory* trajRich = dynamic_cast<G4RichTrajectory*>(trajectory)) {
+            initialKE = trajRich->GetInitialKineticEnergy();
+          }
+          else if (G4SmoothTrajectory* trajSmooth = dynamic_cast<G4SmoothTrajectory*>(trajectory)) {
+            initialKE = trajSmooth->GetInitialKineticEnergy();
+          }
+
+          // Write extended properties
+          m_output << initialKE/CLHEP::MeV << ","
+                  << initialMomentum.x()/CLHEP::MeV << ","
+                  << initialMomentum.y()/CLHEP::MeV << ","
+                  << initialMomentum.z()/CLHEP::MeV
+                  << std::endl;
+
+          // Write trajectory points
+          writeTrajectoryPoints(trajectory, eventID, trajectory->GetTrackID());
+        }
+      }
+    };
+  }
+}
+
+// Register the plugin with DD4hep
+#include "DDG4/Factories.h"
+DECLARE_GEANT4ACTION(TrajectoryWriterEventAction)

--- a/src/TextDumpingSteppingAction.cpp
+++ b/src/TextDumpingSteppingAction.cpp
@@ -77,8 +77,7 @@ namespace dd4hep {
                 info("+++ Total Steps: %ld", m_total_steps);
                 info("+++ Total Tracks written: %ld", m_total_tracks);
                 info("+++ Total Events written: %ld", m_total_events);
-                info("+++ Per Event steps: %ld, tracks: %ld",
-                     (int) m_total_steps/m_total_events, (int) m_total_tracks/m_total_events);
+                // info("+++ Per Event steps: %ld, tracks: %ld", (int) m_total_steps/m_total_events, (int) m_total_tracks/m_total_events);
 
                 // Do we need it here? It should be done automatically
                 if(m_output_file.is_open() && m_output_file.good()) {

--- a/stepping_steering.py
+++ b/stepping_steering.py
@@ -1,0 +1,45 @@
+from DDSim.DD4hepSimulation import DD4hepSimulation
+from g4units import mm, GeV, MeV, m
+import DDG4
+import argparse
+import sys
+
+
+# This printout is to check this steering file is using
+print("== STARTED STEERING FILE ==")
+print(f"g4units: mm={mm}, GeV={GeV}, MeV={MeV}")
+
+
+# Determine output file name
+# Intercept  --outputFile flag
+parser = argparse.ArgumentParser()
+parser.add_argument('--outputFile', type=str, default="output", help='Output file name')
+args, _ = parser.parse_known_args()
+
+# Remove '.edm4hep.root' and append '.txtevt' or use default name (if no --outputFile is given)
+outputFile = args.outputFile if args.outputFile else "output"
+if outputFile.endswith('.edm4hep.root'):
+    outputFile = outputFile[:-len('.edm4hep.root')] + '.evt.txt'
+else:
+    outputFile += '.evt.txt'
+
+print(f"Steering event display 'outputFile' = {outputFile}")
+
+# This is needed for stepping file
+SIM = DD4hepSimulation()
+
+# Need DDG4 kernel to add stepping
+kernel = DDG4.Kernel()
+
+# Instantiate the stepping action
+stepping = DDG4.SteppingAction(kernel, 'TextDumpingSteppingAction/MyStepper')
+stepping.OutputFileName = outputFile
+stepping.OnlyPrimary = False
+stepping.MomentumMin = 150
+stepping.VertexCut = True              # Cut tracks which vertex is outside z_min-z_max range
+stepping.VertexZMin = -5000            # [mm] Min Z for Vertex Cut. Will work only if VertexCut = True
+stepping.VertexZMax = 5000             # [mm] Max Z for Vertex Cut. Will work only if VertexCut = True
+
+kernel.steppingAction().add(stepping)
+
+print("== ENDED STEERING FILE ==")

--- a/trajectory_steering.py
+++ b/trajectory_steering.py
@@ -1,0 +1,73 @@
+from DDSim.DD4hepSimulation import DD4hepSimulation
+from g4units import mm, GeV, MeV, m
+import DDG4
+import argparse
+import sys
+
+
+# This printout is to check this steering file is using
+print("== STARTED STEERING FILE ==")
+print(f"g4units: mm={mm}, GeV={GeV}, MeV={MeV}")
+
+
+# Determine output file name
+# Intercept  --outputFile flag
+parser = argparse.ArgumentParser()
+parser.add_argument('--outputFile', type=str, default="output", help='Output file name')
+args, _ = parser.parse_known_args()
+
+# Remove '.edm4hep.root' and append '.txtevt' or use default name (if no --outputFile is given)
+outputFile = args.outputFile if args.outputFile else "output"
+if outputFile.endswith('.edm4hep.root'):
+    outputFile = outputFile[:-len('.edm4hep.root')] + '.evt.txt'
+else:
+    outputFile += '.evt.txt'
+
+print(f"Steering event display 'outputFile' = {outputFile}")
+
+# This is needed for stepping file
+SIM = DD4hepSimulation()
+
+# Enable UI in the simulation
+#SIM.enableUI()
+
+# Set UI commands to enable trajectory storage
+# These commands need to be executed before the first event
+SIM.ui.commandsConfigure = [
+    f'/tracking/storeTrajectory 2',
+    '/tracking/verbose 1',
+    # Optional: command to draw trajectories in visualization (if used)
+    #'/vis/scene/add/trajectories rich'
+]
+
+# Need DDG4 kernel to add stepping
+kernel = DDG4.Kernel()
+
+# # Set up the UI manager and commands
+# ui = DDG4.Action(kernel, "Geant4UIManager/UI")
+# ui.Commands = [
+#     # Make sure trajectories are stored
+#     f'/tracking/storeTrajectory 2',
+#     # Verbose level for tracking
+#     '/tracking/verbose 1',
+#     # Optional: command to draw trajectories in visualization (if used)
+#     '/vis/scene/add/trajectories rich'
+# ]
+# kernel.registerGlobalAction(ui)
+
+# Instantiate the stepping action
+event_action = DDG4.EventAction(kernel, 'TrajectoryWriterEventAction/TrajectoryWriter')
+# stepping = DDG4.SteppingAction(kernel, 'TextDumpingSteppingAction/MyStepper')
+# stepping.OutputFileName = outputFile
+# stepping.OnlyPrimary = False
+# stepping.MomentumMin = 150
+# stepping.VertexCut = True              # Cut tracks which vertex is outside z_min-z_max range
+# stepping.VertexZMin = -5000            # [mm] Min Z for Vertex Cut. Will work only if VertexCut = True
+# stepping.VertexZMax = 5000             # [mm] Max Z for Vertex Cut. Will work only if VertexCut = True
+
+#kernel.steppingAction().add(stepping)
+kernel.eventAction().add(event_action)
+print("dir(kernel)")
+print(dir(kernel))
+
+print("== ENDED STEERING FILE ==")


### PR DESCRIPTION
Fixes #2

This PR updates plugin so that it uses now can use trajectories stored in event and EventAction instead of Stepping action. The idea of it is that trajectories are the intended way for such things and using stepping-actions - not